### PR TITLE
Redid weapon slots

### DIFF
--- a/lua/weapons/weapon_acf_30cal.lua
+++ b/lua/weapons/weapon_acf_30cal.lua
@@ -17,7 +17,7 @@ SWEP.ShotSound				= Sound("Weapon_30cal.Shoot")
 SWEP.WorldModel             = "models/weapons/30cal/w_30cal.mdl"
 SWEP.HoldType               = "ar2"
 
-SWEP.Slot                   = 0
+SWEP.Slot                   = 3
 SWEP.SlotPos                = 0
 
 SWEP.Spawnable              = true

--- a/lua/weapons/weapon_acf_357magnum.lua
+++ b/lua/weapons/weapon_acf_357magnum.lua
@@ -16,7 +16,7 @@ SWEP.ShotSound				= Sound("Weapon_357.Single")
 SWEP.WorldModel             = "models/weapons/w_357.mdl"
 SWEP.HoldType               = "revolver"
 
-SWEP.Slot                   = 3
+SWEP.Slot                   = 1
 SWEP.SlotPos                = 0
 
 SWEP.Spawnable              = true

--- a/lua/weapons/weapon_acf_57.lua
+++ b/lua/weapons/weapon_acf_57.lua
@@ -12,7 +12,7 @@ SWEP.ShotSound				= Sound(")weapons/fiveseven/fiveseven-1.wav")
 SWEP.WorldModel             = "models/weapons/w_pist_fiveseven.mdl"
 SWEP.HoldType               = "pistol"
 
-SWEP.Slot                   = 3
+SWEP.Slot                   = 1
 SWEP.SlotPos                = 0
 
 SWEP.Spawnable              = true

--- a/lua/weapons/weapon_acf_ak47.lua
+++ b/lua/weapons/weapon_acf_ak47.lua
@@ -13,7 +13,7 @@ SWEP.ShotSound				= Sound(")weapons/ak47/ak47-1.wav")
 SWEP.WorldModel             = "models/weapons/w_rif_ak47.mdl"
 SWEP.HoldType               = "ar2"
 
-SWEP.Slot                   = 0
+SWEP.Slot                   = 2
 SWEP.SlotPos                = 0
 
 SWEP.Spawnable              = true

--- a/lua/weapons/weapon_acf_amr.lua
+++ b/lua/weapons/weapon_acf_amr.lua
@@ -15,7 +15,7 @@ SWEP.ShotSound				= Sound(")acf_base/weapons/sniper_fire.mp3")
 SWEP.WorldModel             = "models/weapons/w_sniper.mdl"
 SWEP.HoldType               = "ar2"
 
-SWEP.Slot                   = 4
+SWEP.Slot                   = 3
 SWEP.SlotPos                = 0
 
 SWEP.Spawnable              = true

--- a/lua/weapons/weapon_acf_aug.lua
+++ b/lua/weapons/weapon_acf_aug.lua
@@ -15,7 +15,7 @@ SWEP.ShotSound				= Sound(")weapons/aug/aug-1.wav")
 SWEP.WorldModel             = "models/weapons/w_rif_aug.mdl"
 SWEP.HoldType               = "smg"
 
-SWEP.Slot                   = 0
+SWEP.Slot                   = 2
 SWEP.SlotPos                = 0
 
 SWEP.Spawnable              = true

--- a/lua/weapons/weapon_acf_bar.lua
+++ b/lua/weapons/weapon_acf_bar.lua
@@ -17,7 +17,7 @@ SWEP.ShotSound				= Sound("Weapon_Bar.Shoot")
 SWEP.WorldModel             = "models/weapons/bar/w_bar.mdl"
 SWEP.HoldType               = "ar2"
 
-SWEP.Slot                   = 0
+SWEP.Slot                   = 3
 SWEP.SlotPos                = 0
 
 SWEP.Spawnable              = true

--- a/lua/weapons/weapon_acf_c96.lua
+++ b/lua/weapons/weapon_acf_c96.lua
@@ -17,7 +17,7 @@ SWEP.ShotSound				= Sound("Weapon_C96.Shoot") -- wrong one, I know, but the norm
 SWEP.WorldModel             = "models/weapons/c96/w_c96.mdl"
 SWEP.HoldType               = "pistol"
 
-SWEP.Slot                   = 3
+SWEP.Slot                   = 1
 SWEP.SlotPos                = 0
 
 SWEP.Spawnable              = true

--- a/lua/weapons/weapon_acf_colt.lua
+++ b/lua/weapons/weapon_acf_colt.lua
@@ -17,7 +17,7 @@ SWEP.ShotSound				= Sound("Weapon_Colt.Shoot")
 SWEP.WorldModel             = "models/weapons/colt/w_colt.mdl"
 SWEP.HoldType               = "pistol"
 
-SWEP.Slot                   = 3
+SWEP.Slot                   = 1
 SWEP.SlotPos                = 0
 
 SWEP.Spawnable              = true

--- a/lua/weapons/weapon_acf_crossbow.lua
+++ b/lua/weapons/weapon_acf_crossbow.lua
@@ -15,7 +15,7 @@ SWEP.ShotSound				= Sound("Weapon_Crossbow.Single")
 SWEP.WorldModel             = "models/weapons/w_crossbow.mdl"
 SWEP.HoldType               = "crossbow"
 
-SWEP.Slot                   = 4
+SWEP.Slot                   = 3
 SWEP.SlotPos                = 0
 
 SWEP.Spawnable              = true

--- a/lua/weapons/weapon_acf_deagle.lua
+++ b/lua/weapons/weapon_acf_deagle.lua
@@ -13,7 +13,7 @@ SWEP.ShotSound				= Sound(")weapons/deagle/deagle-1.wav")
 SWEP.WorldModel             = "models/weapons/w_pist_deagle.mdl"
 SWEP.HoldType               = "pistol"
 
-SWEP.Slot                   = 3
+SWEP.Slot                   = 1
 SWEP.SlotPos                = 0
 
 SWEP.Spawnable              = true

--- a/lua/weapons/weapon_acf_famas.lua
+++ b/lua/weapons/weapon_acf_famas.lua
@@ -13,7 +13,7 @@ SWEP.ShotSound				= Sound(")weapons/famas/famas-1.wav")
 SWEP.WorldModel             = "models/weapons/w_rif_famas.mdl"
 SWEP.HoldType               = "ar2"
 
-SWEP.Slot                   = 0
+SWEP.Slot                   = 2
 SWEP.SlotPos                = 0
 
 SWEP.Spawnable              = true

--- a/lua/weapons/weapon_acf_g3sg1.lua
+++ b/lua/weapons/weapon_acf_g3sg1.lua
@@ -12,7 +12,7 @@ SWEP.ShotSound				= Sound(")weapons/g3sg1/g3sg1-1.wav")
 SWEP.WorldModel             = "models/weapons/w_snip_g3sg1.mdl"
 SWEP.HoldType               = "ar2"
 
-SWEP.Slot                   = 1
+SWEP.Slot                   = 3
 SWEP.SlotPos                = 0
 
 SWEP.Spawnable              = true

--- a/lua/weapons/weapon_acf_g3sg1.lua
+++ b/lua/weapons/weapon_acf_g3sg1.lua
@@ -12,7 +12,7 @@ SWEP.ShotSound				= Sound(")weapons/g3sg1/g3sg1-1.wav")
 SWEP.WorldModel             = "models/weapons/w_snip_g3sg1.mdl"
 SWEP.HoldType               = "ar2"
 
-SWEP.Slot                   = 3
+SWEP.Slot                   = 2
 SWEP.SlotPos                = 0
 
 SWEP.Spawnable              = true

--- a/lua/weapons/weapon_acf_galil.lua
+++ b/lua/weapons/weapon_acf_galil.lua
@@ -13,7 +13,7 @@ SWEP.ShotSound				= Sound(")weapons/galil/galil-1.wav")
 SWEP.WorldModel             = "models/weapons/w_rif_galil.mdl"
 SWEP.HoldType               = "ar2"
 
-SWEP.Slot                   = 0
+SWEP.Slot                   = 2
 SWEP.SlotPos                = 0
 
 SWEP.Spawnable              = true

--- a/lua/weapons/weapon_acf_garand.lua
+++ b/lua/weapons/weapon_acf_garand.lua
@@ -17,7 +17,7 @@ SWEP.ShotSound				= Sound("Weapon_Garand.Shoot")
 SWEP.WorldModel             = "models/weapons/garand/w_garand.mdl"
 SWEP.HoldType               = "ar2"
 
-SWEP.Slot                   = 1
+SWEP.Slot                   = 3
 SWEP.SlotPos                = 0
 
 SWEP.Spawnable              = true

--- a/lua/weapons/weapon_acf_glock.lua
+++ b/lua/weapons/weapon_acf_glock.lua
@@ -13,7 +13,7 @@ SWEP.ShotSound				= Sound(")weapons/glock/glock18-1.wav")
 SWEP.WorldModel             = "models/weapons/w_pist_glock18.mdl"
 SWEP.HoldType               = "revolver"
 
-SWEP.Slot                   = 3
+SWEP.Slot                   = 1
 SWEP.SlotPos                = 0
 
 SWEP.Spawnable              = true

--- a/lua/weapons/weapon_acf_kar98k.lua
+++ b/lua/weapons/weapon_acf_kar98k.lua
@@ -17,7 +17,7 @@ SWEP.ShotSound				= Sound("Weapon_Kar.Shoot")
 SWEP.WorldModel             = "models/weapons/k98/w_k98.mdl"
 SWEP.HoldType               = "ar2"
 
-SWEP.Slot                   = 1
+SWEP.Slot                   = 3
 SWEP.SlotPos                = 0
 
 SWEP.Spawnable              = true

--- a/lua/weapons/weapon_acf_kar98kscoped.lua
+++ b/lua/weapons/weapon_acf_kar98kscoped.lua
@@ -17,7 +17,7 @@ SWEP.ShotSound				= Sound("Weapon_KarScoped.Shoot") -- why different sounds for 
 SWEP.WorldModel             = "models/weapons/k98/w_k98s.mdl"
 SWEP.HoldType               = "ar2"
 
-SWEP.Slot                   = 1
+SWEP.Slot                   = 3
 SWEP.SlotPos                = 0
 
 SWEP.Spawnable              = true

--- a/lua/weapons/weapon_acf_lapua.lua
+++ b/lua/weapons/weapon_acf_lapua.lua
@@ -13,7 +13,7 @@ SWEP.ShotSound				= Sound(")weapons/awp/awp1.wav")
 SWEP.WorldModel             = "models/weapons/w_snip_awp.mdl"
 SWEP.HoldType               = "ar2"
 
-SWEP.Slot                   = 1
+SWEP.Slot                   = 3
 SWEP.SlotPos                = 0
 
 SWEP.Spawnable              = true

--- a/lua/weapons/weapon_acf_m1carbine.lua
+++ b/lua/weapons/weapon_acf_m1carbine.lua
@@ -17,7 +17,7 @@ SWEP.ShotSound				= Sound("Weapon_Carbine.Shoot")
 SWEP.WorldModel             = "models/weapons/m1carbine/w_m1carb.mdl"
 SWEP.HoldType               = "ar2"
 
-SWEP.Slot                   = 1
+SWEP.Slot                   = 2
 SWEP.SlotPos                = 0
 
 SWEP.Spawnable              = true

--- a/lua/weapons/weapon_acf_m249.lua
+++ b/lua/weapons/weapon_acf_m249.lua
@@ -16,7 +16,7 @@ SWEP.ShotSound				= Sound(")weapons/m249/m249-1.wav")
 SWEP.WorldModel             = "models/weapons/w_mach_m249para.mdl"
 SWEP.HoldType               = "ar2"
 
-SWEP.Slot                   = 0
+SWEP.Slot                   = 3
 SWEP.SlotPos                = 0
 
 SWEP.Spawnable              = true

--- a/lua/weapons/weapon_acf_m3shotgun.lua
+++ b/lua/weapons/weapon_acf_m3shotgun.lua
@@ -12,7 +12,7 @@ SWEP.ShotSound				= Sound(")weapons/m3/m3-1.wav")
 SWEP.WorldModel             = "models/weapons/w_shot_m3super90.mdl"
 SWEP.HoldType               = "shotgun"
 
-SWEP.Slot                   = 1
+SWEP.Slot                   = 3
 SWEP.SlotPos                = 0
 
 SWEP.Spawnable              = true

--- a/lua/weapons/weapon_acf_m4a1.lua
+++ b/lua/weapons/weapon_acf_m4a1.lua
@@ -13,7 +13,7 @@ SWEP.ShotSound				= Sound(")weapons/m4a1/m4a1_unsil-1.wav")
 SWEP.WorldModel             = "models/weapons/w_rif_m4a1.mdl"
 SWEP.HoldType               = "ar2"
 
-SWEP.Slot                   = 0
+SWEP.Slot                   = 2
 SWEP.SlotPos                = 0
 
 SWEP.Spawnable              = true

--- a/lua/weapons/weapon_acf_mg42.lua
+++ b/lua/weapons/weapon_acf_mg42.lua
@@ -17,7 +17,7 @@ SWEP.ShotSound				= Sound("Weapon_Mg42.Shoot")
 SWEP.WorldModel             = "models/weapons/mg42/w_mg42bd.mdl"
 SWEP.HoldType               = "ar2"
 
-SWEP.Slot                   = 0
+SWEP.Slot                   = 3
 SWEP.SlotPos                = 0
 
 SWEP.Spawnable              = true

--- a/lua/weapons/weapon_acf_mp40.lua
+++ b/lua/weapons/weapon_acf_mp40.lua
@@ -17,7 +17,7 @@ SWEP.ShotSound				= Sound("Weapon_Mp40.Shoot")
 SWEP.WorldModel             = "models/weapons/mp40/w_mp40.mdl"
 SWEP.HoldType               = "smg"
 
-SWEP.Slot                   = 0
+SWEP.Slot                   = 2
 SWEP.SlotPos                = 0
 
 SWEP.Spawnable              = true

--- a/lua/weapons/weapon_acf_mp44.lua
+++ b/lua/weapons/weapon_acf_mp44.lua
@@ -17,7 +17,7 @@ SWEP.ShotSound				= Sound("Weapon_Mp44.Shoot")
 SWEP.WorldModel             = "models/weapons/mp44/w_mp44.mdl"
 SWEP.HoldType               = "ar2"
 
-SWEP.Slot                   = 0
+SWEP.Slot                   = 2
 SWEP.SlotPos                = 0
 
 SWEP.Spawnable              = true

--- a/lua/weapons/weapon_acf_p38.lua
+++ b/lua/weapons/weapon_acf_p38.lua
@@ -17,7 +17,7 @@ SWEP.ShotSound				= Sound("Weapon_C96.Shoot") -- wrong one, I know, but the norm
 SWEP.WorldModel             = "models/weapons/p38/w_p38.mdl"
 SWEP.HoldType               = "pistol"
 
-SWEP.Slot                   = 3
+SWEP.Slot                   = 1
 SWEP.SlotPos                = 0
 
 SWEP.Spawnable              = true

--- a/lua/weapons/weapon_acf_scout.lua
+++ b/lua/weapons/weapon_acf_scout.lua
@@ -12,7 +12,7 @@ SWEP.ShotSound				= Sound(")weapons/scout/scout_fire-1.wav")
 SWEP.WorldModel             = "models/weapons/w_snip_scout.mdl"
 SWEP.HoldType               = "ar2"
 
-SWEP.Slot                   = 1
+SWEP.Slot                   = 3
 SWEP.SlotPos                = 0
 
 SWEP.Spawnable              = true

--- a/lua/weapons/weapon_acf_sg550.lua
+++ b/lua/weapons/weapon_acf_sg550.lua
@@ -12,7 +12,7 @@ SWEP.ShotSound				= Sound(")weapons/sg550/sg550-1.wav")
 SWEP.WorldModel             = "models/weapons/w_snip_sg550.mdl"
 SWEP.HoldType               = "ar2"
 
-SWEP.Slot                   = 0
+SWEP.Slot                   = 2
 SWEP.SlotPos                = 0
 
 SWEP.Spawnable              = true

--- a/lua/weapons/weapon_acf_sg552.lua
+++ b/lua/weapons/weapon_acf_sg552.lua
@@ -15,7 +15,7 @@ SWEP.ShotSound				= Sound(")weapons/sg552/sg552-1.wav")
 SWEP.WorldModel             = "models/weapons/w_rif_sg552.mdl"
 SWEP.HoldType               = "smg"
 
-SWEP.Slot                   = 0
+SWEP.Slot                   = 2
 SWEP.SlotPos                = 0
 
 SWEP.Spawnable              = true

--- a/lua/weapons/weapon_acf_springfield.lua
+++ b/lua/weapons/weapon_acf_springfield.lua
@@ -17,7 +17,7 @@ SWEP.ShotSound				= Sound("Weapon_Springfield.Shoot")
 SWEP.WorldModel             = "models/weapons/springfield/w_spring.mdl"
 SWEP.HoldType               = "ar2"
 
-SWEP.Slot                   = 1
+SWEP.Slot                   = 3
 SWEP.SlotPos                = 0
 
 SWEP.Spawnable              = true

--- a/lua/weapons/weapon_acf_usp.lua
+++ b/lua/weapons/weapon_acf_usp.lua
@@ -13,7 +13,7 @@ SWEP.ShotSound				= Sound(")weapons/usp/usp_unsil-1.wav")
 SWEP.WorldModel             = "models/weapons/w_pist_usp.mdl"
 SWEP.HoldType               = "pistol"
 
-SWEP.Slot                   = 3
+SWEP.Slot                   = 1
 SWEP.SlotPos                = 0
 
 SWEP.Spawnable              = true


### PR DESCRIPTION
Redid weapon slots to be more like TacRP. Pistols go in slot 2, SMGs and ARs go in slot 3, Snipers, Shotguns, and MGs go in slot 4, and launchers go in slot 5. This should be better than having pistols in slot 3.