### PR TITLE
Movement reset bug fix and applying carryspeedmul to all weapons

### DIFF
--- a/lua/autorun/acf3sweps_bootstrap.lua
+++ b/lua/autorun/acf3sweps_bootstrap.lua
@@ -380,4 +380,6 @@ do
     sound.Add({name = "Weapon_Thompson.WorldReload", channel = 3, volume = 0.76953125, level = 65, pitch = 100, sound = "thompson/thompson_worldreload.wav"})
 end
 
+CreateConVar("acf_sweps_speed_mult", "1", true, false)
+
 print("ACF-3 SWEPs ready!")

--- a/lua/weapons/weapon_acf3r_smaw.lua
+++ b/lua/weapons/weapon_acf3r_smaw.lua
@@ -32,6 +32,7 @@ SWEP.Primary.DefaultClip    = 1
 SWEP.Primary.Ammo           = "RPG_Round"
 SWEP.Primary.Automatic      = false
 SWEP.Primary.Delay          = 0.15
+SWEP.CarrySpeedMul			= 0.6
 
 SWEP.UseHybrid				= false
 

--- a/lua/weapons/weapon_acf_30cal.lua
+++ b/lua/weapons/weapon_acf_30cal.lua
@@ -32,6 +32,7 @@ SWEP.Primary.DefaultClip    = 250
 SWEP.Primary.Ammo           = "AR2"
 SWEP.Primary.Automatic      = true
 SWEP.Primary.Delay          = 0.1
+SWEP.CarrySpeedMul			= 0.65
 
 SWEP.Caliber                = 7.8 -- mm diameter of bullet
 SWEP.ACFProjMass            = 0.01 -- kg of projectile

--- a/lua/weapons/weapon_acf_357magnum.lua
+++ b/lua/weapons/weapon_acf_357magnum.lua
@@ -31,6 +31,7 @@ SWEP.Primary.DefaultClip    = 6
 SWEP.Primary.Ammo           = "357"
 SWEP.Primary.Automatic      = false
 SWEP.Primary.Delay          = 0.2
+SWEP.CarrySpeedMul			= 1.0
 
 SWEP.Caliber                = 9.06 -- mm diameter of bullet
 SWEP.ACFProjMass            = 0.014 -- kg of projectile

--- a/lua/weapons/weapon_acf_57.lua
+++ b/lua/weapons/weapon_acf_57.lua
@@ -27,6 +27,7 @@ SWEP.Primary.DefaultClip    = 20
 SWEP.Primary.Ammo           = "Pistol"
 SWEP.Primary.Automatic      = false
 SWEP.Primary.Delay          = 0.12
+SWEP.CarrySpeedMul			= 1.0
 
 SWEP.CalcDistance			= 25
 SWEP.CalcDistance2			= 50

--- a/lua/weapons/weapon_acf_ak47.lua
+++ b/lua/weapons/weapon_acf_ak47.lua
@@ -28,6 +28,7 @@ SWEP.Primary.DefaultClip    = 30
 SWEP.Primary.Ammo           = "SMG1"
 SWEP.Primary.Automatic      = true
 SWEP.Primary.Delay          = 0.1
+SWEP.CarrySpeedMul			= 0.8
 SWEP.FiremodeSetting		= 2
 
 SWEP.Caliber                = 7.62 -- mm diameter of bullet

--- a/lua/weapons/weapon_acf_amr.lua
+++ b/lua/weapons/weapon_acf_amr.lua
@@ -29,6 +29,7 @@ SWEP.Primary.ClipSize       = 1
 SWEP.Primary.DefaultClip    = 1
 SWEP.Primary.Ammo           = "XBowBolt"
 SWEP.Primary.Automatic      = false
+SWEP.CarrySpeedMul			= 0.6
 SWEP.Primary.Delay          = 1.25
 
 SWEP.UseHybrid				= false

--- a/lua/weapons/weapon_acf_aug.lua
+++ b/lua/weapons/weapon_acf_aug.lua
@@ -30,6 +30,7 @@ SWEP.Primary.DefaultClip    = 30
 SWEP.Primary.Ammo           = "SMG1"
 SWEP.Primary.Automatic      = true
 SWEP.Primary.Delay          = 0.085
+SWEP.CarrySpeedMul			= 0.8
 SWEP.FiremodeSetting		= 2
 
 SWEP.Caliber                = 5.56 -- mm diameter of bullet

--- a/lua/weapons/weapon_acf_bar.lua
+++ b/lua/weapons/weapon_acf_bar.lua
@@ -32,6 +32,7 @@ SWEP.Primary.DefaultClip    = 20
 SWEP.Primary.Ammo           = "AR2"
 SWEP.Primary.Automatic      = true
 SWEP.Primary.Delay          = 0.1
+SWEP.CarrySpeedMul			= 0.8
 SWEP.FiremodeSetting		= 2
 
 SWEP.Caliber                = 7.8 -- mm diameter of bullet

--- a/lua/weapons/weapon_acf_base.lua
+++ b/lua/weapons/weapon_acf_base.lua
@@ -500,8 +500,13 @@ function SWEP:Deploy()
 		self.NormalPlayerWalkSpeed = self.OriginalWalkSpeed
 		self.NormalPlayerRunSpeed = self.OriginalRunSpeed
 
-		owner:SetWalkSpeed( self.NormalPlayerWalkSpeed * self.CarrySpeedMul)
-		owner:SetRunSpeed( self.NormalPlayerRunSpeed * self.CarrySpeedMul * 1)
+		if  GetConVar("acf_sweps_speed_mult", 1):GetBool() then
+			owner:SetWalkSpeed( self.NormalPlayerWalkSpeed * self.CarrySpeedMul)
+			owner:SetRunSpeed( self.NormalPlayerRunSpeed * self.CarrySpeedMul)
+		else
+			owner:SetWalkSpeed( self.NormalPlayerWalkSpeed )
+			owner:SetRunSpeed( self.NormalPlayerRunSpeed )
+		end
 	end
 
 	if self.HasDropCalc then self.DropCalc = self:CalcDropTable() end

--- a/lua/weapons/weapon_acf_base.lua
+++ b/lua/weapons/weapon_acf_base.lua
@@ -492,8 +492,13 @@ function SWEP:Deploy()
 
 		local owner = self:GetOwner()
 
-		self.NormalPlayerWalkSpeed = owner:GetWalkSpeed()
-		self.NormalPlayerRunSpeed = owner:GetRunSpeed()
+		if not self.OriginalWalkSpeed then
+			self.OriginalWalkSpeed = owner:GetWalkSpeed()
+			self.OriginalRunSpeed = owner:GetRunSpeed()
+		end
+
+		self.NormalPlayerWalkSpeed = self.OriginalWalkSpeed
+		self.NormalPlayerRunSpeed = self.OriginalRunSpeed
 
 		owner:SetWalkSpeed( self.NormalPlayerWalkSpeed * self.CarrySpeedMul)
 		owner:SetRunSpeed( self.NormalPlayerRunSpeed * self.CarrySpeedMul * 1)
@@ -511,6 +516,16 @@ function SWEP:Deploy()
 	if self.Bullet.Type == "HE" or self.Bullet.Type == "HEAT" then
 		self:SetNW2Float("FillerMass", self.Bullet.FillerMass)
 	end
+
+	return true
+end
+
+function SWEP:OnRemove()
+	local owner = self:GetOwner()
+	if IsValid(owner) and owner:IsPlayer() then
+		owner:SetWalkSpeed(self.OriginalWalkSpeed or self.NormalPlayerWalkSpeed)
+		owner:SetRunSpeed(self.OriginalRunSpeed or self.NormalPlayerRunSpeed)
+	end
 end
 
 function SWEP:Holster()
@@ -519,6 +534,14 @@ function SWEP:Holster()
 
 	self:SetNWBool("iron", false)
 	self.IronScale = 0
+
+	if SERVER then
+		local owner = self:GetOwner()
+		if IsValid(owner) and owner:IsPlayer() then
+			owner:SetWalkSpeed(self.OriginalWalkSpeed or self.NormalPlayerWalkSpeed)
+			owner:SetRunSpeed(self.OriginalRunSpeed or self.NormalPlayerRunSpeed)
+		end
+	end
 
 	return true
 end

--- a/lua/weapons/weapon_acf_c96.lua
+++ b/lua/weapons/weapon_acf_c96.lua
@@ -32,6 +32,7 @@ SWEP.Primary.DefaultClip    = 20
 SWEP.Primary.Ammo           = "Pistol"
 SWEP.Primary.Automatic      = true
 SWEP.Primary.Delay          = 0.07
+SWEP.CarrySpeedMul			= 1.0
 
 SWEP.CalcDistance			= 25
 SWEP.CalcDistance2			= 50

--- a/lua/weapons/weapon_acf_colt.lua
+++ b/lua/weapons/weapon_acf_colt.lua
@@ -32,6 +32,7 @@ SWEP.Primary.DefaultClip    = 7
 SWEP.Primary.Ammo           = "Pistol"
 SWEP.Primary.Automatic      = false
 SWEP.Primary.Delay          = 0.13
+SWEP.CarrySpeedMul			= 1.0
 
 SWEP.CalcDistance			= 25
 SWEP.CalcDistance2			= 50

--- a/lua/weapons/weapon_acf_crossbow.lua
+++ b/lua/weapons/weapon_acf_crossbow.lua
@@ -30,6 +30,7 @@ SWEP.Primary.DefaultClip    = 1
 SWEP.Primary.Ammo           = "XBowBolt"
 SWEP.Primary.Automatic      = false
 SWEP.Primary.Delay          = 1.25
+SWEP.CarrySpeedMul			= 1.0
 
 SWEP.CalcDistance			= 100
 SWEP.CalcDistance2			= 300

--- a/lua/weapons/weapon_acf_deagle.lua
+++ b/lua/weapons/weapon_acf_deagle.lua
@@ -28,6 +28,7 @@ SWEP.Primary.DefaultClip    = 7
 SWEP.Primary.Ammo           = "Pistol"
 SWEP.Primary.Automatic      = false
 SWEP.Primary.Delay          = 0.23
+SWEP.CarrySpeedMul			= 1.0
 
 SWEP.CalcDistance			= 25
 SWEP.CalcDistance2			= 50

--- a/lua/weapons/weapon_acf_famas.lua
+++ b/lua/weapons/weapon_acf_famas.lua
@@ -28,6 +28,7 @@ SWEP.Primary.DefaultClip    = 25
 SWEP.Primary.Ammo           = "SMG1"
 SWEP.Primary.Automatic      = true
 SWEP.Primary.Delay          = 0.05454
+SWEP.CarrySpeedMul			= 0.8
 SWEP.FiremodeSetting		= 2
 
 SWEP.Caliber                = 5.56 -- mm diameter of bullet

--- a/lua/weapons/weapon_acf_g3sg1.lua
+++ b/lua/weapons/weapon_acf_g3sg1.lua
@@ -27,6 +27,7 @@ SWEP.Primary.DefaultClip    = 20
 SWEP.Primary.Ammo           = "AR2"
 SWEP.Primary.Automatic      = false
 SWEP.Primary.Delay          = 0.1
+SWEP.CarrySpeedMul			= 0.8
 SWEP.FiremodeSetting		= 1
 
 SWEP.Caliber                = 7.62 -- mm diameter of bullet

--- a/lua/weapons/weapon_acf_galil.lua
+++ b/lua/weapons/weapon_acf_galil.lua
@@ -28,6 +28,7 @@ SWEP.Primary.DefaultClip    = 25
 SWEP.Primary.Ammo           = "AR2"
 SWEP.Primary.Automatic      = true
 SWEP.Primary.Delay          = 0.092
+SWEP.CarrySpeedMul			= 0.8
 SWEP.FiremodeSetting		= 2
 
 SWEP.Caliber                = 7.62 -- mm diameter of bullet

--- a/lua/weapons/weapon_acf_garand.lua
+++ b/lua/weapons/weapon_acf_garand.lua
@@ -32,6 +32,7 @@ SWEP.Primary.DefaultClip    = 8
 SWEP.Primary.Ammo           = "357"
 SWEP.Primary.Automatic      = false
 SWEP.Primary.Delay          = 0.2
+SWEP.CarrySpeedMul			= 0.8
 
 SWEP.Caliber                = 7.62 -- mm diameter of bullet
 SWEP.ACFProjMass            = 0.01 -- kg of projectile

--- a/lua/weapons/weapon_acf_glock.lua
+++ b/lua/weapons/weapon_acf_glock.lua
@@ -28,6 +28,7 @@ SWEP.Primary.DefaultClip    = 24
 SWEP.Primary.Ammo           = "Pistol"
 SWEP.Primary.Automatic      = true
 SWEP.Primary.Delay          = 0.06
+SWEP.CarrySpeedMul			= 1.0
 SWEP.FiremodeSetting		= 2
 
 SWEP.Caliber                = 9 -- mm diameter of bullet

--- a/lua/weapons/weapon_acf_grenadelauncher.lua
+++ b/lua/weapons/weapon_acf_grenadelauncher.lua
@@ -31,6 +31,7 @@ SWEP.Primary.DefaultClip    = 5
 SWEP.Primary.Ammo           = "SMG1_Grenade"
 SWEP.Primary.Automatic      = false
 SWEP.Primary.Delay          = 0.3
+SWEP.CarrySpeedMul			= 0.6
 
 SWEP.UseHybrid				= false
 

--- a/lua/weapons/weapon_acf_kar98k.lua
+++ b/lua/weapons/weapon_acf_kar98k.lua
@@ -32,6 +32,7 @@ SWEP.Primary.DefaultClip    = 5
 SWEP.Primary.Ammo           = "AR2"
 SWEP.Primary.Automatic      = false
 SWEP.Primary.Delay          = 1.2
+SWEP.CarrySpeedMul			= 0.8
 
 SWEP.Caliber                = 7.92 -- mm diameter of bullet
 SWEP.ACFProjMass            = 0.011 -- kg of projectile

--- a/lua/weapons/weapon_acf_kar98kscoped.lua
+++ b/lua/weapons/weapon_acf_kar98kscoped.lua
@@ -32,6 +32,7 @@ SWEP.Primary.DefaultClip    = 5
 SWEP.Primary.Ammo           = "AR2"
 SWEP.Primary.Automatic      = false
 SWEP.Primary.Delay          = 1.5
+SWEP.CarrySpeedMul			= 0.7
 
 SWEP.CalcDistance			= 100
 SWEP.CalcDistance2			= 300

--- a/lua/weapons/weapon_acf_lapua.lua
+++ b/lua/weapons/weapon_acf_lapua.lua
@@ -28,6 +28,7 @@ SWEP.Primary.DefaultClip    = 5
 SWEP.Primary.Ammo           = "AR2"
 SWEP.Primary.Automatic      = false
 SWEP.Primary.Delay          = 1.25
+SWEP.CarrySpeedMul			= 0.7
 
 SWEP.Caliber                = 8.61 -- mm diameter of bullet
 SWEP.ACFProjMass            = 0.0162 -- kg of projectile

--- a/lua/weapons/weapon_acf_m1carbine.lua
+++ b/lua/weapons/weapon_acf_m1carbine.lua
@@ -32,6 +32,7 @@ SWEP.Primary.DefaultClip    = 30
 SWEP.Primary.Ammo           = "SMG1"
 SWEP.Primary.Automatic      = false
 SWEP.Primary.Delay          = 0.15
+SWEP.CarrySpeedMul			= 0.8
 
 SWEP.Caliber                = 7.8 -- mm diameter of bullet
 SWEP.ACFProjMass            = 0.007 -- kg of projectile

--- a/lua/weapons/weapon_acf_m1thompson.lua
+++ b/lua/weapons/weapon_acf_m1thompson.lua
@@ -33,6 +33,7 @@ SWEP.Primary.Ammo           = "SMG1"
 SWEP.Primary.Automatic      = true
 SWEP.Primary.Delay          = 0.085
 SWEP.FiremodeSetting		= 2
+SWEP.CarrySpeedMul			= 0.9
 
 SWEP.CalcDistance			= 25
 SWEP.CalcDistance2			= 50

--- a/lua/weapons/weapon_acf_m249.lua
+++ b/lua/weapons/weapon_acf_m249.lua
@@ -31,6 +31,7 @@ SWEP.Primary.DefaultClip    = 100
 SWEP.Primary.Ammo           = "SMG1"
 SWEP.Primary.Automatic      = true
 SWEP.Primary.Delay          = 0.075
+SWEP.CarrySpeedMul			= 0.65
 SWEP.FiremodeSetting		= 2
 
 SWEP.Caliber                = 5.56

--- a/lua/weapons/weapon_acf_m3shotgun.lua
+++ b/lua/weapons/weapon_acf_m3shotgun.lua
@@ -29,6 +29,7 @@ SWEP.Primary.DefaultClip    = 7
 SWEP.Primary.Ammo           = "Buckshot"
 SWEP.Primary.Automatic      = false
 SWEP.Primary.Delay          = 0.9
+SWEP.CarrySpeedMul			= 0.8
 
 SWEP.CalcDistance			= 25
 SWEP.CalcDistance2			= 50

--- a/lua/weapons/weapon_acf_m4a1.lua
+++ b/lua/weapons/weapon_acf_m4a1.lua
@@ -28,6 +28,7 @@ SWEP.Primary.DefaultClip    = 30
 SWEP.Primary.Ammo           = "SMG1"
 SWEP.Primary.Automatic      = true
 SWEP.Primary.Delay          = 0.075
+SWEP.CarrySpeedMul			= 0.8
 SWEP.FiremodeSetting		= 2
 
 SWEP.Caliber                = 5.56 -- mm diameter of bullet

--- a/lua/weapons/weapon_acf_mg42.lua
+++ b/lua/weapons/weapon_acf_mg42.lua
@@ -32,6 +32,7 @@ SWEP.Primary.DefaultClip    = 250
 SWEP.Primary.Ammo           = "AR2"
 SWEP.Primary.Automatic      = true
 SWEP.Primary.Delay          = 0.05
+SWEP.CarrySpeedMul			= 0.65
 
 SWEP.Caliber                = 7.92 -- mm diameter of bullet
 SWEP.ACFProjMass            = 0.011 -- kg of projectile

--- a/lua/weapons/weapon_acf_mp40.lua
+++ b/lua/weapons/weapon_acf_mp40.lua
@@ -32,6 +32,7 @@ SWEP.Primary.DefaultClip    = 30
 SWEP.Primary.Ammo           = "SMG1"
 SWEP.Primary.Automatic      = false
 SWEP.Primary.Delay          = 0.12
+SWEP.CarrySpeedMul			= 0.9
 SWEP.FiremodeSetting		= 2
 
 SWEP.Caliber                = 9 -- mm diameter of bullet

--- a/lua/weapons/weapon_acf_mp44.lua
+++ b/lua/weapons/weapon_acf_mp44.lua
@@ -32,6 +32,7 @@ SWEP.Primary.DefaultClip    = 30
 SWEP.Primary.Ammo           = "SMG1"
 SWEP.Primary.Automatic      = true
 SWEP.Primary.Delay          = 0.1
+SWEP.CarrySpeedMul			= 0.8
 SWEP.FiremodeSetting		= 2
 
 SWEP.Caliber                = 7.92 -- mm diameter of bullet

--- a/lua/weapons/weapon_acf_mp5.lua
+++ b/lua/weapons/weapon_acf_mp5.lua
@@ -28,6 +28,7 @@ SWEP.Primary.DefaultClip    = 30
 SWEP.Primary.Ammo           = "Pistol"
 SWEP.Primary.Automatic      = true
 SWEP.Primary.Delay          = 0.075
+SWEP.CarrySpeedMul			= 0.9
 SWEP.FiremodeSetting		= 2
 
 SWEP.CalcDistance			= 25

--- a/lua/weapons/weapon_acf_p38.lua
+++ b/lua/weapons/weapon_acf_p38.lua
@@ -32,6 +32,7 @@ SWEP.Primary.DefaultClip    = 8
 SWEP.Primary.Ammo           = "Pistol"
 SWEP.Primary.Automatic      = false
 SWEP.Primary.Delay          = 0.13
+SWEP.CarrySpeedMul			= 1.0
 
 SWEP.CalcDistance			= 25
 SWEP.CalcDistance2			= 50

--- a/lua/weapons/weapon_acf_p90.lua
+++ b/lua/weapons/weapon_acf_p90.lua
@@ -28,6 +28,7 @@ SWEP.Primary.DefaultClip    = 50
 SWEP.Primary.Ammo           = "Pistol"
 SWEP.Primary.Automatic      = true
 SWEP.Primary.Delay          = 0.06
+SWEP.CarrySpeedMul			= 0.9
 SWEP.FiremodeSetting		= 2
 
 SWEP.CalcDistance			= 25

--- a/lua/weapons/weapon_acf_panzerschreck.lua
+++ b/lua/weapons/weapon_acf_panzerschreck.lua
@@ -32,6 +32,7 @@ SWEP.Primary.DefaultClip    = 1
 SWEP.Primary.Ammo           = "RPG_Round"
 SWEP.Primary.Automatic      = false
 SWEP.Primary.Delay          = 0.2
+SWEP.CarrySpeedMul			= 0.6
 
 SWEP.UseHybrid				= false
 

--- a/lua/weapons/weapon_acf_scout.lua
+++ b/lua/weapons/weapon_acf_scout.lua
@@ -27,6 +27,7 @@ SWEP.Primary.DefaultClip    = 5
 SWEP.Primary.Ammo           = "AR2"
 SWEP.Primary.Automatic      = false
 SWEP.Primary.Delay          = 1.25
+SWEP.CarrySpeedMul			= 0.7
 
 SWEP.Caliber                = 7.62 -- mm diameter of bullet
 SWEP.ACFProjMass            = 0.011 -- kg of projectile

--- a/lua/weapons/weapon_acf_sg550.lua
+++ b/lua/weapons/weapon_acf_sg550.lua
@@ -27,6 +27,7 @@ SWEP.Primary.DefaultClip    = 30
 SWEP.Primary.Ammo           = "AR2"
 SWEP.Primary.Automatic      = true
 SWEP.Primary.Delay          = 0.085
+SWEP.CarrySpeedMul			= 0.8
 SWEP.FiremodeSetting		= 2
 
 SWEP.Caliber                = 5.56 -- mm diameter of bullet

--- a/lua/weapons/weapon_acf_sg552.lua
+++ b/lua/weapons/weapon_acf_sg552.lua
@@ -30,6 +30,7 @@ SWEP.Primary.DefaultClip    = 30
 SWEP.Primary.Ammo           = "SMG1"
 SWEP.Primary.Automatic      = true
 SWEP.Primary.Delay          = 0.085
+SWEP.CarrySpeedMul			= 0.8
 SWEP.FiremodeSetting		= 2
 
 SWEP.CalcDistance			= 100

--- a/lua/weapons/weapon_acf_springfield.lua
+++ b/lua/weapons/weapon_acf_springfield.lua
@@ -32,6 +32,7 @@ SWEP.Primary.DefaultClip    = 5
 SWEP.Primary.Ammo           = "AR2"
 SWEP.Primary.Automatic      = false
 SWEP.Primary.Delay          = 1.5
+SWEP.CarrySpeedMul			= 0.7
 
 SWEP.CalcDistance			= 100
 SWEP.CalcDistance2			= 300

--- a/lua/weapons/weapon_acf_ump45.lua
+++ b/lua/weapons/weapon_acf_ump45.lua
@@ -28,6 +28,7 @@ SWEP.Primary.DefaultClip    = 25
 SWEP.Primary.Ammo           = "Pistol"
 SWEP.Primary.Automatic      = true
 SWEP.Primary.Delay          = 0.1
+SWEP.CarrySpeedMul			= 0.9
 SWEP.FiremodeSetting		= 2
 
 SWEP.CalcDistance			= 25

--- a/lua/weapons/weapon_acf_usp.lua
+++ b/lua/weapons/weapon_acf_usp.lua
@@ -28,6 +28,7 @@ SWEP.Primary.DefaultClip    = 8
 SWEP.Primary.Ammo           = "Pistol"
 SWEP.Primary.Automatic      = false
 SWEP.Primary.Delay          = 0.15
+SWEP.CarrySpeedMul			= 1.0
 
 SWEP.Caliber                = 11.5 -- mm diameter of bullet
 SWEP.ACFProjMass            = 0.015 -- kg of projectile


### PR DESCRIPTION
- fixed an issue where the player's speed would not reset after holstering weapon
- added CarrySpeedMul to all weapons Pistols and crossbow left unaffected by movement speed multiplier (1.0) SMGs set to 0.9 of default movespeed
Rifles and shotguns set to 0.8 of default
Sniper rifles set to 0.7 of default
LMGs set to 0.65 of default
Launchers, anti-material rifle, and XM25 set to 0.6 of default